### PR TITLE
Add metadata json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,8 @@
+{
+   "name": "example-ospfunnum-puppet",
+   "dependencies" : [
+      { "name": "cumuluslinux/cumulus_interfaces" },
+      { "name": "cumuluslinux/cumulus_ports"}
+    ]
+}
+


### PR DESCRIPTION
librarian-puppet complains and wants a metadata.json installed. so this PR puts the dependencies in the metadata.json instead of in the Puppetfile.

