### PR TITLE
CE-1054 License path is wrong

### DIFF
--- a/modules/base/manifests/license.pp
+++ b/modules/base/manifests/license.pp
@@ -8,7 +8,7 @@ class base::license {
   }
 
   cumulus_license { 'workbench':
-    src => "puppet:///modules/base/${::hostname}.lic",
+    src => "http://wbench.lab.local/${::hostname}.lic",
     notify => Service['switchd']
   }
 


### PR DESCRIPTION
Use http:// like the rest of the demos, rather than trying to retrieve the
license from the Puppet master.